### PR TITLE
Show some useful database statistics

### DIFF
--- a/routes/database.js
+++ b/routes/database.js
@@ -1,7 +1,17 @@
+var utils = require('../utils');
+
 exports.viewDatabase = function(req, res) {
-  var ctx = {
-    title: 'Viewing Database: ' + req.dbName,
-    colls: req.collections[req.dbName]
-  };
-  res.render('database', ctx);
+  req.db.stats(function(err, data){
+	  var ctx = {
+		title: 'Viewing Database: ' + req.dbName,
+		colls: req.collections[req.dbName],
+		stats: {
+			collections: data.collections,
+			dataSize: utils.bytesToSize(data.dataSize),
+			storageSize: utils.bytesToSize(data.storageSize),
+			fileSize: utils.bytesToSize(data.fileSize)
+		}
+	  };
+	  res.render('database', ctx);
+  });  
 }

--- a/utils.js
+++ b/utils.js
@@ -9,3 +9,13 @@ exports.parseCollectionName = function parseCollectionName(full_name) {
   var database = coll_parts.splice(0,1);
   return { name: coll_parts.join('.'), database: database.toString() };
 };
+
+// Given some size in bytes, returns it in a converted, friendly size
+// credits: http://stackoverflow.com/users/1596799/aliceljm
+exports.bytesToSize = function bytesToSize(bytes) {
+   if(bytes == 0) return '0 Byte';
+   var k = 1000;
+   var sizes = [' bytes', 'kb', 'mb', 'gb', 'tb', 'pb', 'eb', 'zb', 'yb'];
+   var i = Math.floor(Math.log(bytes) / Math.log(k));
+   return (bytes / Math.pow(k, i)).toPrecision(3) + ' ' + sizes[i];
+}

--- a/views/database.html
+++ b/views/database.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 <div class="stats">
-	<h2>Database Status</h2>
+	<h2>Database Stats</h2>
 	<table class="table table-bordered table-striped">
 	  <tr>
 		<td class="span2"><strong>Collections (including system.namespaces)</strong></td>

--- a/views/database.html
+++ b/views/database.html
@@ -14,6 +14,28 @@
 
 
 {% block content %}
+<div class="stats">
+	<h2>Database Status</h2>
+	<table class="table table-bordered table-striped">
+	  <tr>
+		<td class="span2"><strong>Collections (including system.namespaces)</strong></td>
+		<td class="span3">{{ stats.collections }}</td>
+	  </tr>
+	  <tr>
+		<td><strong>Data Size</strong></td>
+		<td>{{ stats.dataSize }}</td>
+	  </tr>
+	  <tr>
+		<td><strong>Storage Size</strong></td>
+		<td>{{ stats.storageSize }}</td>
+	  </tr>
+	  <tr>
+		<td><strong>File Size (on disk)</strong></td>
+		<td>{{ stats.fileSize }}</td>
+	  </tr>
+	</table>
+</div>
+
 <h2>Create Collection</h2>
 <form class="well form-inline" method="POST">
     <div class="input-prepend">
@@ -51,7 +73,6 @@
    });
  });
 </script>
-
 
 <h2>Collections</h2>
 <table class="table table-bordered table-striped table-condensed">


### PR DESCRIPTION
Hello,

I felt displaying some statistics in the home page of every database might be really helpful. I have given a screenshot of how this shows up below:

![db_stats](https://cloud.githubusercontent.com/assets/1248984/5913197/ca08f99a-a5ad-11e4-8bac-64f713b693ae.png)

Thanks!
