### PR TITLE
Make mongo-express works with cloudfoundry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ npm-debug.log
 
 config.js
 admins.json
+manifest.yml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mongo-express
 =============
 
-Web-based MongoDB admin interface written with Node.js and express
+Web-based MongoDB admin interface written with Node.js and express and works great with cloudfoundry
 
 [![Build Status](https://secure.travis-ci.org/andzdroid/mongo-express.png?branch=master)](http://travis-ci.org/andzdroid/mongo-express) - Master (stable) branch
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mongo-express
 =============
 
-Web-based MongoDB admin interface written with Node.js and express and works great with cloudfoundry
+Web-based MongoDB admin interface written with Node.js and express and works great with cloudfoundry just bind a service with mongodb inside his name, app will find by itself (use regular expression).
 
 [![Build Status](https://secure.travis-ci.org/andzdroid/mongo-express.png?branch=master)](http://travis-ci.org/andzdroid/mongo-express) - Master (stable) branch
 

--- a/app.js
+++ b/app.js
@@ -49,10 +49,9 @@ app.configure('development', function(){
 
 
 //Set up database stuff
-
-if(config.mongodb.service){
-  var appEnv = cfenv.getAppEnv();
-  var serviceMongo = appEnv.getService(config.mongodb.service);
+var appEnv = cfenv.getAppEnv();
+  var serviceMongo = appEnv.getService(/.*mongodb.*/i);
+if(serviceMongo != null){
   config.mongodb.server = serviceMongo.credentials.host;
   config.mongodb.port = serviceMongo.credentials.port;
   config.mongodb.adminUsername = serviceMongo.credentials.username;

--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ var cons = require('consolidate');
 var swig = require('swig');
 var swigFilters = require('./filters');
 var app = express();
-
+var cfenv = require('cfenv');
 var config = require('./config');
 
 //Set up swig
@@ -49,6 +49,16 @@ app.configure('development', function(){
 
 
 //Set up database stuff
+
+if(config.mongodb.service){
+  var appEnv = cfenv.getAppEnv();
+  var serviceMongo = appEnv.getService(config.mongodb.service);
+  config.mongodb.server = serviceMongo.credentials.host;
+  config.mongodb.port = serviceMongo.credentials.port;
+  config.mongodb.adminUsername = serviceMongo.credentials.username;
+  config.mongodb.adminPassword = serviceMongo.credentials.password;
+  config.mongodb.auth.push({'database': serviceMongo.credentials.db, 'username': serviceMongo.credentials.username, 'password': serviceMongo.credentials.password});
+}
 var host = config.mongodb.server || 'localhost';
 var port = config.mongodb.port || mongodb.Connection.DEFAULT_PORT;
 var dbOptions = {
@@ -309,8 +319,9 @@ app.get(config.site.baseUrl+'db/:database', middleware, routes.viewDatabase);
 
 //run as standalone App?
 if (require.main === module){
-  app.listen(config.site.port);
-  console.log("Mongo Express server listening on port " + (config.site.port || 80));
+  var port = process.env.PORT || config.site.port;
+  app.listen(port);
+  console.log("Mongo Express server listening on port " + (port || 80));
 }else{
   //as a module
   console.log('Mongo Express module ready to use on route "'+config.site.baseUrl+'*"');

--- a/config.default.js
+++ b/config.default.js
@@ -1,5 +1,6 @@
 module.exports = {
   mongodb: {
+    service: 'mongodb-ahalet',
     server: 'localhost',
     port: 27017,
 

--- a/config.default.js
+++ b/config.default.js
@@ -1,7 +1,5 @@
 module.exports = {
   mongodb: {
-    //set the service name to make it work with cloudfoundry and that's all
-    service: '',
     server: 'localhost',
     port: 27017,
 

--- a/config.default.js
+++ b/config.default.js
@@ -1,6 +1,7 @@
 module.exports = {
   mongodb: {
-    service: 'mongodb-ahalet',
+    //set the service name to make it work with cloudfoundry and that's all
+    service: '',
     server: 'localhost',
     port: 27017,
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/andzdroid/mongo-express.git"
   },
   "dependencies": {
+    "cfenv": "1.0.0",
     "express": "~3.4.8",
     "mongodb": "~1.3.23",
     "consolidate": "~0.10.0",


### PR DESCRIPTION
I've made some changes if you are interested. Your app is now available to works with a cloud platform (cloudfoundry) it does not affect your preexistent code it's just cloudfoundry compliant and can use services from him. 