### PR TITLE
Issue #13 : Fix document ID URL encoding on get, put and delete

### DIFF
--- a/views/collection.html
+++ b/views/collection.html
@@ -143,7 +143,7 @@ No documents found.
 {% if collectionName != 'system.indexes' %}
 <script type="text/javascript">
 function loadDocument(id) {
-  location.href = '{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/' + id;
+  location.href = '{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/' + encodeURIComponent(id);
 }
 </script>
 {% endif %}
@@ -182,7 +182,7 @@ function loadDocument(id) {
 </div>
 <div class="span1">
   <br /><br />
-  <form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/{{ docs[loop.index0]._id|to_string }}">
+  <form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/{{ docs[loop.index0]._id|to_string|url_encode }}">
   <input type="hidden" name="_method" value="delete">
   <button type="submit" class="btn btn-danger btn-mini">
   <i class="icon-remove icon-white"></i>

--- a/views/document.html
+++ b/views/document.html
@@ -43,7 +43,7 @@
 
 {% block content %}
 
-<form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/{{ document._id|to_string }}">
+<form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/{{ document._id|to_string|url_encode }}">
   <input type="hidden" name="_method" value="put">
   <button type="submit" class="btn btn-success btn-large"{# onclick="return checkJSON()"#}>
     <i class="icon-pencil icon-white"></i>


### PR DESCRIPTION
I used the `url_encode` swig filter to URL encode document ID on **delete** and **put**.
And I used the native `encodeURIComponent` JavaScript function in `loadDocument(id)` to fix the **get**. 

Related to issue https://github.com/andzdroid/mongo-express/issues/13

PS: I think there is a general lack of URL encoding on all dynamic links, not only on document ID parameters.

PPS: This is my very first contribution to a GitHub open source project.. Please tell me if I did something wrong :)