### PR TITLE
create image from official node repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/nodejs
+FROM node:latest
 
 WORKDIR /app
 ADD . /app
@@ -8,5 +8,5 @@ RUN cp config.default.js config.js
 
 EXPOSE 8081
 
-CMD ["/nodejs/bin/npm", "start"]
+CMD ["npm", "start"]
 


### PR DESCRIPTION
The google/nodejs repo is deprecated and the docker build was broken because of it.

i updated the dockerfile to pull from the official node.js repo(the latest version)