### PR TITLE
Add more environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ You can use the following [environment variables](https://docs.docker.com/refere
 - Description: MongoDB port.
 - Default value: `27017`
 
+- Variable name: `ME_CONFIG_MONGODB_ADMINUSERNAME`
+- Description: Administrator username.
+- Default value: ``
+
+- Variable name: `ME_CONFIG_MONGODB_ADMINPASSWORD`
+- Description: Administrator password.
+- Default value: ``
 
 - Variable name: `ME_CONFIG_SITE_COOKIESECRET`
 - Description: String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.
@@ -127,13 +134,17 @@ You can use the following [environment variables](https://docs.docker.com/refere
 
 
 - Variable name: `ME_CONFIG_BASICAUTH_USERNAME`
-- Description: mongo-express login name.
+- Description: mongo-express login name. Sending an empty string will disable basic authentication.
 - Default value: `admin`
 
 
 - Variable name: `ME_CONFIG_BASICAUTH_PASSWORD`
 - Description: mongo-express login password.
-- Default value `pass`:
+- Default value `pass`
+
+- Variable name: `ME_CONFIG_OPTIONS_EDITORTHEME`
+- Description: Web editor color theme.
+- Default value: `rubyblue`
 
 -
 

--- a/config.default.js
+++ b/config.default.js
@@ -40,8 +40,8 @@ module.exports = {
     //  >>>>  Using an admin account allows you to view and edit all databases, and view stats
 
     //leave username and password empty if no admin account exists
-    adminUsername: '',
-    adminPassword: '',
+    adminUsername: process.env.ME_CONFIG_MONGODB_ADMINUSERNAME || '',
+    adminPassword: process.env.ME_CONFIG_MONGODB_ADMINPASSWORD || '',
     //whitelist: hide all databases except the ones in this list  (empty list for no whitelist)
     whitelist: [],
     //blacklist: hide databases listed in the blacklist (empty list for no blacklist)
@@ -56,9 +56,10 @@ module.exports = {
     cookieKeyName: 'mongo-express'
   },
 
-  //set ifBasicAuth to true if you want to basicAuth before login mongo-express
+  //set useBasicAuth to true if you want to authehticate mongo-express loggins
   //if admin is false, the basicAuthInfo list below will be ignored
-  useBasicAuth: true,
+  //this will be true unless ME_CONFIG_BASICAUTH_USERNAME is set and is the empty string
+  useBasicAuth: process.env.ME_CONFIG_BASICAUTH_USERNAME != '',
 
   basicAuth: {
     username: process.env.ME_CONFIG_BASICAUTH_USERNAME || 'admin',
@@ -70,7 +71,7 @@ module.exports = {
     documentsPerPage: 10,
     //editorTheme: Name of the theme you want to use for displaying documents
     //See http://codemirror.net/demo/theme.html for all examples
-    editorTheme: 'rubyblue',
+    editorTheme: process.env.ME_CONFIG_OPTIONS_EDITORTHEME || 'rubyblue',
 
     //The options below aren't being used yet
 


### PR DESCRIPTION
In addition to adminUsername, adminPassword, and editorTheme, I had the idea that basic authentication could be turned off automatically if a blank username is provided through an environment variable.
  (undefined != '') => true // basic auth enabled when undefined
     ('asdf' != '') => true // basic auth enabled when username is provided
         ('' != '') => false // basic auth disabled when the empty string