### PR TITLE
Adding accordian and configurable fields from a document for display in collections list page.

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -84,5 +84,21 @@ module.exports = {
     subprocessTimeout: 300,
     //readOnly: if readOnly is true, components of writing are not visible.
     readOnly: true
-  }
+  },
+
+	// Specify the default keyname that should be picked from a document to display in collections list.
+	// Keynames can be specified for every database and collection.
+	// If no keyname is specified, it defalts to '_id', which is a mandatory feild.
+	// For Example :
+	//
+	// defaultKeyNames{
+	//	"world_db":{  //Database Name
+	//		"continent":"cont_name", // collection:feild
+	//		"country":"country_name",
+	//		"city":"name"
+	//	}
+  //}
+	defaultKeyNames: {
+
+	}
 };

--- a/routes/collection.js
+++ b/routes/collection.js
@@ -25,6 +25,9 @@ var routes = function(config) {
     var type = req.query.type || '';
     var jsonQuery = req.query.query || '';
     var jsonFields = req.query.fields || '';
+    var dbName = req.params.database;
+    var collectionName = req.params.collection;
+    var defaultKey = config.defaultKeyNames[dbName][collectionName] || '_id';
 
     if (key && value) {
       // If type == J, convert value as json document
@@ -109,7 +112,8 @@ var routes = function(config) {
           value: value,
           type: type,
           query: jsonQuery,
-          fields: jsonFields
+          fields: jsonFields,
+          defaultKey: defaultKey
         };
 
         res.render('collection', ctx);

--- a/views/collection.html
+++ b/views/collection.html
@@ -163,38 +163,59 @@ function loadDocument(id) {
   <li class="next"><a href="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}?skip={{ last }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&fields= {{ fields }}">Last &rarr;</a></li>
 </ul>
 
-{% for document in documents %}
-<div class="row">
-<div class="span8">
-  <textarea readonly="readonly" id="doc_{{ loop.index }}" name="doc_{{ loop.index }}">{{ document }}</textarea>
-  <p>&nbsp;</p>
-
-  <script>
-    var doc_{{ loop.index }} = CodeMirror.fromTextArea(document.getElementById('doc_{{ loop.index }}'), {
-      mode: { name: "javascript", json: true },
-      readOnly: true,
-      indentUnit: 4,
-      theme: "{{ editorTheme }}",
-      lineNumbers: true
-      {%- if collectionName != 'system.indexes' && collectionName != 'system.users' %},
-      onFocus: function() { loadDocument('{{ docs[loop.index0]._id|to_string }}') }
-      {%- endif %}
-    });
-  </script>
+<table class="table table-striped">
+{% for document in docs %}
+<tr><td>
+<div class="accordian span9" id="_accordian">
+  <div class="accordian-group">
+      <div class="accordian-heading">
+        <a class="accordian-toggle" data-toggle="collapse" data-parent="_accordian" href="#body_{{ loop.index}}">
+          {% if document[defaultKey] == "" %}
+            {{defaultKey}} is empty for {{document["_id"]|to_string}}
+          {% else %}
+            {{document[defaultKey] |to_string}}
+          {% endif %}
+        </a>
+      </div>
+      <div class="accordian-body collapse" id="body_{{ loop.index}}">
+        <div class="accordion-inner">
+          <div class="row">
+          <div class="span9">
+            <textarea readonly="readonly" id="doc_{{ loop.index }}" name="doc_{{ loop.index }}">{{ document | json }}</textarea>
+            <script>
+              var doc_{{ loop.index }} = CodeMirror.fromTextArea(document.getElementById('doc_{{ loop.index }}'), {
+                mode: { name: "javascript", json: true },
+                readOnly: true,
+                indentUnit: 4,
+                theme: "{{ editorTheme }}",
+                lineNumbers: true
+                {%- if collectionName != 'system.indexes' && collectionName != 'system.users' %},
+                onFocus: function() { loadDocument('{{ docs[loop.index0]._id|to_string }}') }
+                {%- endif %}
+              });
+            </script>
+          </div>
+          </div>
+        </div>
+      </div>
+  </div>
 </div>
+</td>
 {% if !settings.read_only %}
-<div class="span1">
-  <br /><br />
-  <form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/{{ docs[loop.index0]._id|to_string|url_encode }}">
-  <input type="hidden" name="_method" value="delete">
-  <button type="submit" class="btn btn-danger btn-mini">
-  <i class="icon-remove icon-white"></i>
-  </button>
-  </form>
-</div>
+<td>
+  <div class="span1">
+    <form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/{{ docs[loop.index0]._id|to_string|url_encode }}">
+    <input type="hidden" name="_method" value="delete">
+    <button type="submit" class="btn btn-danger btn-mini">
+    <i class="icon-remove icon-white"></i>
+    </button>
+    </form>
+  </div>
+</td>
 {% endif %}
-</div>
+</tr>
 {% endfor %}
+</table>
 
 <div class="pagination pagination-centered span7">
   <ul>


### PR DESCRIPTION
In most of my use cases I am generally interested in looking at one field, which helps me find the document I want. So, this commit provides the flexibility of specifying a key name for every collection and databse in the config, whose corresponding value is shown in the list documents of collection view.

This also adds an accordian to the list so that more docs can be displayed in lesser space.

![pr1](https://cloud.githubusercontent.com/assets/3775612/10743397/ba33d256-7c58-11e5-834f-91e5a510ee76.png)
![pr2](https://cloud.githubusercontent.com/assets/3775612/10743398/ba38338c-7c58-11e5-9518-4bfa890cf827.png)
