### PR TITLE
Fix bug when defaultKeyNames are not set, accessing property of undefined #115

### DIFF
--- a/routes/collection.js
+++ b/routes/collection.js
@@ -27,7 +27,7 @@ var routes = function(config) {
     var jsonFields = req.query.fields || '';
     var dbName = req.params.database;
     var collectionName = req.params.collection;
-    var defaultKey = config.defaultKeyNames[dbName][collectionName] || '_id';
+    var defaultKey = (config.defaultKeyNames && config.defaultKeyNames[dbName] && config.defaultKeyNames[dbName][collectionName]) ? config.defaultKeyNames[dbName][collectionName] : '_id';
 
     if (key && value) {
       // If type == J, convert value as json document


### PR DESCRIPTION
Fixed issue addressed in a comment #115 

Code now checks that defaultKeyNames are defined before accessing them