### PR TITLE
Add SSL capabilities and configuration to mongo-express

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,8 +8,23 @@ var app = express();
 
 app.use('/', middleware(config));
 app.set('read_only', config.options.readOnly || false);
-app.listen(config.site.port, config.site.host, function() {
+
+var defaultPort = 80;
+var server      = app;
+
+if (config.site.sslEnabled){
+  defaultPort     = 443;
+  var https       = require('https');
+  var fs          = require('fs');
+  var sslOptions  = {
+    key:  fs.readFileSync(config.site.sslKey),
+    cert: fs.readFileSync(config.site.sslCert)
+  };
+  server          = https.createServer(sslOptions, app);
+}
+
+server.listen(config.site.port, config.site.host, function() {
   console.log('Mongo Express server listening',
-    'on port ' + (config.site.port || 80),
-    'at ' + (config.site.host || '0.0.0.0'));
+      'on port ' + (config.site.port || defaultPort),
+      'at ' + (config.site.host || '0.0.0.0'));
 });

--- a/config.default.js
+++ b/config.default.js
@@ -53,7 +53,10 @@ module.exports = {
     port: 8081,
     cookieSecret: process.env.ME_CONFIG_SITE_COOKIESECRET || 'cookiesecret',
     sessionSecret: process.env.ME_CONFIG_SITE_SESSIONSECRET || 'sessionsecret',
-    cookieKeyName: 'mongo-express'
+    cookieKeyName: 'mongo-express',
+    sslEnabled: process.env.ME_CONFIG_SITE_SSL_ENABLED || false,
+    sslCert: process.env.ME_CONFIG_SITE_SSL_CRT_PATH || '',
+    sslKey: process.env.ME_CONFIG_SITE_SSL_KEY_PATH || ''
   },
 
   //set useBasicAuth to true if you want to authehticate mongo-express loggins


### PR DESCRIPTION
I've made changes that would add ssl capabilities only if user specifies it should be enabled. By default it is the same as running the application before. 