### PR TITLE
Add embedded document notation to defaultKey #60

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -29,3 +29,7 @@ exports.convertBytes = function(input) {
 exports.to_string = function (input) {
     return input !== null ? input.toString() : '';
 };
+
+exports.is_embeddedDocumentNotation = function (input) {
+  return /^(?:[a-zA-Z0-9_]+\.)+[a-zA-Z0-9_]+/.test(input);
+}

--- a/routes/collection.js
+++ b/routes/collection.js
@@ -30,6 +30,16 @@ var routes = function(config) {
     var defaultKey = (config.defaultKeyNames && config.defaultKeyNames[dbName] && config.defaultKeyNames[dbName][collectionName]) ?
       config.defaultKeyNames[dbName][collectionName] :
       '_id';
+    var edKey = function (doc, defaultKey) {
+      var defaultKeyAsArray = defaultKey.split('.');
+      var val = doc;
+      for (var i = 0; i < defaultKeyAsArray.length; i++) {
+        if (val[defaultKeyAsArray[i]]) {
+          val = val[defaultKeyAsArray[i]];
+        }
+      }
+      return val;
+    };
 
     if (key && value) {
       // If type == J, convert value as json document
@@ -115,7 +125,8 @@ var routes = function(config) {
           type: type,
           query: jsonQuery,
           fields: jsonFields,
-          defaultKey: defaultKey
+          defaultKey: defaultKey,
+          edKey: edKey
         };
 
         res.render('collection', ctx);

--- a/views/collection.html
+++ b/views/collection.html
@@ -174,7 +174,15 @@ function loadDocument(id) {
           {% if document[defaultKey] == "" %}
             {{defaultKey}} is empty for {{document["_id"]|to_string}}
           {% else %}
-            {{document[defaultKey] |to_string}}
+            {% if !document[defaultKey] %}
+              {% if defaultKey|is_embeddedDocumentNotation %}
+                {{edKey(document, defaultKey)}}
+              {% else %}
+                {{defaultKey}} is undefined for {{document["_id"]|to_string}}
+              {% endif %}
+            {% else %}
+              {{document[defaultKey] |to_string}}
+            {% endif %}
           {% endif %}
         </a>
       </div>


### PR DESCRIPTION
Adds support for embedded document notation when setting defaultKey.

    "someCollection": "object.property.anotherproperty"