### PR TITLE
fixed bug of exporting: removed 'ISODate(' from exported JSON

### DIFF
--- a/bson.js
+++ b/bson.js
@@ -93,6 +93,7 @@ exports.toString = function(doc) {
 exports.toJsonString = function(doc) {
   var sJson = json.stringify(doc, null);
   sJson = sJson.replace(/ObjectID\(/g, '{ "$oid": ');
+  sJson = sJson.replace(/ISODate\(/g, '');
   sJson = sJson.replace(/\)/g, ' }');
   return sJson;
 };


### PR DESCRIPTION
Same as #136, Retrying with another brunch.
Fixed the bug related to Issue #64.
Broken format of ISODate( in exported json files is now removed.