### PR TITLE
Be able to see databases for MongoDB 3.2 

### DIFF
--- a/db.js
+++ b/db.js
@@ -154,13 +154,13 @@ var connect = function(config) {
   });
 
   return {
-    updateCollections: updateCollections,
-    updateDatabases: updateDatabases,
+    adminDb: adminDb,
+    collections: collections,
     connections: connections,
     databases: databases,
-    collections: collections,
-    adminDb: adminDb,
-    mainConn: mainConn
+    mainConn: mainConn,
+    updateCollections: updateCollections,
+    updateDatabases: updateDatabases
   };
 };
 

--- a/db.js
+++ b/db.js
@@ -58,10 +58,8 @@ var connect = function(config) {
         console.error(err);
         databases = _.pluck(config.mongodb.auth, 'database');
       } else {
-
-        for (var key in dbs.databases) {
-          var dbName = dbs.databases[key].name;
-
+        for (var i=0; i< dbs.databases.length; i++) {
+          var dbName = dbs.databases[i].name;
           //'local' is special database, ignore it
           if (dbName === 'local') {
             continue;
@@ -80,13 +78,12 @@ var connect = function(config) {
 
           connections[dbName] = mainConn.db(dbName);
           databases.push(dbName);
-
           updateCollections(connections[dbName], dbName);
         }
       }
       //Sort database names
       databases = databases.sort();
-
+      
       if(callback){
         callback(databases);
       }
@@ -157,13 +154,13 @@ var connect = function(config) {
   });
 
   return {
-    adminDb: adminDb,
-    collections: collections,
+    updateCollections: updateCollections,
+    updateDatabases: updateDatabases,
     connections: connections,
     databases: databases,
-    mainConn: mainConn,
-    updateCollections: updateCollections,
-    updateDatabases: updateDatabases
+    collections: collections,
+    adminDb: adminDb,
+    mainConn: mainConn
   };
 };
 


### PR DESCRIPTION
The listDatabases changed to an array (looks like before it was an object with keys). This change would break backwards compatibility though. Should I check the version and change the way it iterates through the databases? I wasn't sure which mongo version it changed in though, maybe just checking for 3.x would be fine. 