### PR TITLE
Let the admin config bool be set through an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     ----------------------------------|-----------------|------------
     `ME_CONFIG_MONGODB_SERVER`        |`mongo` or `localhost`| MongoDB host name or IP address. The default is `localhost` in the config file and `mongo` in the docker image.
     `ME_CONFIG_MONGODB_PORT`          | `27017`         | MongoDB port.
+    `ME_CONFIG_MONGODB_ENABLE_ADMIN`  | `false`         | Enable administrator access.
     `ME_CONFIG_MONGODB_ADMINUSERNAME` | ` `             | Administrator username.
     `ME_CONFIG_MONGODB_ADMINPASSWORD` | ` `             | Administrator password.
     `ME_CONFIG_SITE_COOKIESECRET`     | `cookiesecret`  | String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.

--- a/config.default.js
+++ b/config.default.js
@@ -41,7 +41,7 @@ module.exports = {
     //set admin to true if you want to turn on admin features
     //if admin is true, the auth list below will be ignored
     //if admin is true, you will need to enter an admin username/password below (if it is needed)
-    admin: false,
+    admin: process.env.ME_CONFIG_MONGODB_ENABLE_ADMIN || false,
 
     // >>>>  If you are using regular accounts, fill out auth details in the section below
     // >>>>  If you have admin auth, leave this section empty and skip to the next section


### PR DESCRIPTION
The easiest way for docker to affect the config is through environment variables :wink:. This fixes #158.