### PR TITLE
Bash can't pass literal 'true', just a truthy value

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -41,7 +41,7 @@ module.exports = {
     //set admin to true if you want to turn on admin features
     //if admin is true, the auth list below will be ignored
     //if admin is true, you will need to enter an admin username/password below (if it is needed)
-    admin: process.env.ME_CONFIG_MONGODB_ENABLE_ADMIN || false,
+    admin: !!process.env.ME_CONFIG_MONGODB_ENABLE_ADMIN || false,
 
     // >>>>  If you are using regular accounts, fill out auth details in the section below
     // >>>>  If you have admin auth, leave this section empty and skip to the next section


### PR DESCRIPTION
I'm sorry, I should have tested this new environment variable better before making a pull request yesterday.