### PR TITLE
Explicitly link the docker port to the host port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN npm install
 RUN cp config.default.js config.js
 
 ENV ME_CONFIG_MONGODB_SERVER="mongo"
+ENV VCAP_APP_HOST="0.0.0.0"
 
 EXPOSE 8081
 CMD ["tini", "--", "npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN npm install
 RUN cp config.default.js config.js
 
 ENV ME_CONFIG_MONGODB_SERVER="mongo"
+ENV ME_CONFIG_MONGODB_ENABLE_ADMIN="true"
 ENV VCAP_APP_HOST="0.0.0.0"
 
 EXPOSE 8081

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ First, build an image from the project directory:
 
 Then run the image. Make sure you have a running [MongoDB container](https://registry.hub.docker.com/_/mongo/) and specify it's name in the `--link` argument.
 
-    docker run -it --rm --link YOUR_MONGODB_CONTAINER:mongo mongo-express
+    docker run -it --rm -p 8081:8081 --link YOUR_MONGODB_CONTAINER:mongo mongo-express
 
 You can use the following [environment variables](https://docs.docker.com/reference/run/#env-environment-variables) to modify the container's configuration:
 
@@ -159,6 +159,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     docker run -it --rm \
         --name mongo-express \
         --link web_db_1:mongo \
+        -p 8081:8081 \
         -e ME_CONFIG_OPTIONS_EDITORTHEME="ambiance" \
         -e ME_CONFIG_BASICAUTH_USERNAME="" \
         mongo-express


### PR DESCRIPTION
I had always run it with a custom port link (`-p 8082:8081`) so I never tested it without one. Turns out it can't connect without it. Also docker connections don't like `localhost` sometimes, to I changed the docker default to `0.0.0.0`.


P.S. I like the new full width page layouts :smile: