### PR TITLE
Make jsons in collection views collapsible, fixes #176

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -125,6 +125,12 @@ module.exports = {
 
     //readOnly: if readOnly is true, components of writing are not visible.
     readOnly: false,
+
+    //collapsibleJSON: if set to true, jsons will be displayed collapsible
+    collapsibleJSON: true,
+    //collapsibleJSONDefaultUnfold: if collapsibleJSON is set to `true`, this defines default level
+    //  to which JSONs are displayed unfolded; use number or "all" to unfold all levels
+    collapsibleJSONDefaultUnfold: 1
   },
 
   // Specify the default keyname that should be picked from a document to display in collections list.

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -184,6 +184,8 @@ var routes = function(config) {
           fields: jsonFields,
           defaultKey: defaultKey,
           edKey: edKey,
+          collapsibleJSON: config.options.collapsibleJSON,
+          collapsibleJSONDefaultUnfold: config.options.collapsibleJSONDefaultUnfold
         };
 
         res.render('collection', ctx);

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -204,6 +204,25 @@ var addDoc = CodeMirror.fromTextArea(document.getElementById('document'), {
 $('#addDocument').on('shown.bs.modal', function() {
   addDoc.refresh();
 });
+
+{% if collapsibleJSON %}
+$(function() {
+  // convert all objects to renderjson elements
+  $("div.tableContent").each(function() {
+    var html = $.trim($(this).html());
+    if (html[0] == "<") {
+      // strip <pre> and </pre> from element content
+      $(this).html(renderjson(JSON.parse(html.slice(5, -6))));
+    }
+  });
+
+  // prevent parent click events if user cliks collapse/uncollapse icon
+  $("pre.renderjson a").click(function(e) {
+    e.stopPropagation();
+  });
+});
+renderjson.set_show_to_level({{ collapsibleJSONDefaultUnfold }});
+{% endif %}
 </script>
 
   {% if documents.length == 0 %}

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -33,6 +33,7 @@
 
   <script src="{{ baseHref }}javascripts/jquery-2.1.4.min.js"></script>
   <script src="{{ baseHref }}javascripts/bootstrap.min.js"></script>
+  <script src="{{ baseHref }}javascripts/renderjson.js"></script>
 
   {% block head %}{% endblock %}
 </head>

--- a/public/javascripts/renderjson.js
+++ b/public/javascripts/renderjson.js
@@ -1,0 +1,189 @@
+// Copyright © 2013-2014 David Caldwell <david@porkrind.org>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// Usage
+// -----
+// The module exports one entry point, the `renderjson()` function. It takes in
+// the JSON you want to render as a single argument and returns an HTML
+// element.
+//
+// Options
+// -------
+// renderjson.set_icons("+", "-")
+//   This Allows you to override the disclosure icons.
+//
+// renderjson.set_show_to_level(level)
+//   Pass the number of levels to expand when rendering. The default is 0, which
+//   starts with everything collapsed. As a special case, if level is the string
+//   "all" then it will start with everything expanded.
+//
+// renderjson.set_max_string_length(length)
+//   Strings will be truncated and made expandable if they are longer than
+//   `length`. As a special case, if `length` is the string "none" then
+//   there will be no truncation. The default is "none".
+//
+// renderjson.set_sort_objects(sort_bool)
+//   Sort objects by key (default: false)
+//
+// Theming
+// -------
+// The HTML output uses a number of classes so that you can theme it the way
+// you'd like:
+//     .disclosure    ("⊕", "⊖")
+//     .syntax        (",", ":", "{", "}", "[", "]")
+//     .string        (includes quotes)
+//     .number
+//     .boolean
+//     .key           (object key)
+//     .keyword       ("null", "undefined")
+//     .object.syntax ("{", "}")
+//     .array.syntax  ("[", "]")
+
+var module;
+(module||{}).exports = renderjson = (function() {
+    var themetext = function(/* [class, text]+ */) {
+        var spans = [];
+        while (arguments.length)
+            spans.push(append(span(Array.prototype.shift.call(arguments)),
+                              text(Array.prototype.shift.call(arguments))));
+        return spans;
+    };
+    var append = function(/* el, ... */) {
+        var el = Array.prototype.shift.call(arguments);
+        for (var a=0; a<arguments.length; a++)
+            if (arguments[a].constructor == Array)
+                append.apply(this, [el].concat(arguments[a]));
+            else
+                el.appendChild(arguments[a]);
+        return el;
+    };
+    var prepend = function(el, child) {
+        el.insertBefore(child, el.firstChild);
+        return el;
+    }
+    var isempty = function(obj) { for (var k in obj) if (obj.hasOwnProperty(k)) return false;
+                                  return true; }
+    var text = function(txt) { return document.createTextNode(txt) };
+    var div = function() { return document.createElement("div") };
+    var span = function(classname) { var s = document.createElement("span");
+                                     if (classname) s.className = classname;
+                                     return s; };
+    var A = function A(txt, classname, callback) { var a = document.createElement("a");
+                                                   if (classname) a.className = classname;
+                                                   a.appendChild(text(txt));
+                                                   a.href = '#';
+                                                   a.onclick = function() { callback(); return false; };
+                                                   return a; };
+
+    function _renderjson(json, indent, dont_indent, show_level, max_string, sort_objects) {
+        var my_indent = dont_indent ? "" : indent;
+
+        var disclosure = function(open, placeholder, close, type, builder) {
+            var content;
+            var empty = span(type);
+            var show = function() { if (!content) append(empty.parentNode,
+                                                         content = prepend(builder(),
+                                                                           A(renderjson.hide, "disclosure",
+                                                                             function() { content.style.display="none";
+                                                                                          empty.style.display="inline"; } )));
+                                    content.style.display="inline";
+                                    empty.style.display="none"; };
+            append(empty,
+                   A(renderjson.show, "disclosure", show),
+                   themetext(type+ " syntax", open),
+                   A(placeholder, null, show),
+                   themetext(type+ " syntax", close));
+
+            var el = append(span(), text(my_indent.slice(0,-1)), empty);
+            if (show_level > 0)
+                show();
+            return el;
+        };
+
+        if (json === null) return themetext(null, my_indent, "keyword", "null");
+        if (json === void 0) return themetext(null, my_indent, "keyword", "undefined");
+
+        if (typeof(json) == "string" && json.length > max_string)
+            return disclosure('"', json.substr(0,max_string)+" ...", '"', "string", function () {
+                return append(span("string"), themetext(null, my_indent, "string", JSON.stringify(json)));
+            });
+
+        if (typeof(json) != "object") // Strings, numbers and bools
+            return themetext(null, my_indent, typeof(json), JSON.stringify(json));
+
+        if (json.constructor == Array) {
+            if (json.length == 0) return themetext(null, my_indent, "array syntax", "[]");
+
+            return disclosure("[", " ... ", "]", "array", function () {
+                var as = append(span("array"), themetext("array syntax", "[", null, "\n"));
+                for (var i=0; i<json.length; i++)
+                    append(as,
+                           _renderjson(json[i], indent+"    ", false, show_level-1, max_string, sort_objects),
+                           i != json.length-1 ? themetext("syntax", ",") : [],
+                           text("\n"));
+                append(as, themetext(null, indent, "array syntax", "]"));
+                return as;
+            });
+        }
+
+        // object
+        if (isempty(json))
+            return themetext(null, my_indent, "object syntax", "{}");
+
+        return disclosure("{", "...", "}", "object", function () {
+            var os = append(span("object"), themetext("object syntax", "{", null, "\n"));
+            for (var k in json) var last = k;
+            var keys = Object.keys(json);
+            if (sort_objects)
+                keys = keys.sort();
+            for (var i in keys) {
+                var k = keys[i];
+                append(os, themetext(null, indent+"    ", "key", '"'+k+'"', "object syntax", ': '),
+                       _renderjson(json[k], indent+"    ", true, show_level-1, max_string, sort_objects),
+                       k != last ? themetext("syntax", ",") : [],
+                       text("\n"));
+            }
+            append(os, themetext(null, indent, "object syntax", "}"));
+            return os;
+        });
+    }
+
+    var renderjson = function renderjson(json)
+    {
+        var pre = append(document.createElement("pre"), _renderjson(json, "", false, renderjson.show_to_level, renderjson.max_string_length, renderjson.sort_objects));
+        pre.className = "renderjson";
+        return pre;
+    }
+    renderjson.set_icons = function(show, hide) { renderjson.show = show;
+                                                  renderjson.hide = hide;
+                                                  return renderjson; };
+    renderjson.set_show_to_level = function(level) { renderjson.show_to_level = typeof level == "string" &&
+                                                                                level.toLowerCase() === "all" ? Number.MAX_VALUE
+                                                                                                              : level;
+                                                     return renderjson; };
+    renderjson.set_max_string_length = function(length) { renderjson.max_string_length = typeof length == "string" &&
+                                                                                         length.toLowerCase() === "none" ? Number.MAX_VALUE
+                                                                                                                         : length;
+                                                          return renderjson; };
+    renderjson.set_sort_objects = function(sort_bool) { renderjson.sort_objects = sort_bool;
+                                                        return renderjson; };
+    // Backwards compatiblity. Use set_show_to_level() for new code.
+    renderjson.set_show_by_default = function(show) { renderjson.show_to_level = show ? Number.MAX_VALUE : 0;
+                                                      return renderjson; };
+    renderjson.set_icons('⊕', '⊖');
+    renderjson.set_show_by_default(false);
+    renderjson.set_sort_objects(false);
+    renderjson.set_max_string_length("none");
+    return renderjson;
+})();


### PR DESCRIPTION
This adds the ability to collapse subobjects using renderjson \[1\].
- renderjson is licensed under ISC \[2\], which according to wikipedia is functionally equivalent with MIT; hopefully that means that there should be no licensing issues, but IANAL
- The implementation is a bit naive - the whole page is loaded first and then a custom JS function traverses all `div.tableContent` elements and if one of them contains JSON string, it parses it and replaces it with renderjson result.
- I've added two configuration options for turning on/off using renderjson and for setting the default unfold level.
- The only issue that I'm experiencing is that the table columns change width when collapsing/uncollapsing. I'm not sure whether that's fixable - I'm not sure whether we should (can) fix it in the first place... I'm just mentioning it for your consideration.

I'm not an experienced JS/frontend developer, so if you see a better way to do something or if you would like me to change the behaviour in some way, please say so.

\[1\] https://github.com/caldwell/renderjson
\[2\] https://en.wikipedia.org/wiki/ISC_license